### PR TITLE
fix minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl -X POST 'http://localhost:4445/admin/clients' \
   "post_logout_redirect_uris": ["http://localhost:4455/login"],
   "response_types": ["code", "id_token"],
   "scope": "openid offline",
-  "token_endpoint_auth_method": "client_secret_post",
+  "token_endpoint_auth_method": "client_secret_post"
 }' && \
 docker exec -it hydra-db psql -U hydra -c "UPDATE hydra_client SET id = 'auth-code-client' WHERE client_name = 'Test OAuth2 Client'"
 ```


### PR DESCRIPTION
Thank you for the great example.
When I command create an OAuth client with the command in README, in my environment, the following error appeared, so I made this modification.
I hope this helps.

```
level=error msg=An error occurred while handling a request audience=application error=map[message:invalid character '}' looking for beginning of object key string stack_trace
```